### PR TITLE
typo: fix spelling of GitHub

### DIFF
--- a/www/components/SiteNav/index.tsx
+++ b/www/components/SiteNav/index.tsx
@@ -38,7 +38,7 @@ export default function SiteNav() {
           rel="noopener noreferrer"
           className="text-md"
         >
-          Github
+          GitHub
         </a>
       </div>
     </div>


### PR DESCRIPTION
- github is spelled "GitHub" not "Github"