### PR TITLE
merkle: fix proof performance

### DIFF
--- a/merkle/tree.go
+++ b/merkle/tree.go
@@ -87,14 +87,16 @@ func (t Tree) Root() []byte {
 // The result of this func will be used in [Valid]
 func (t Tree) Proof(target []byte) [][]byte {
 	var (
-		proof [][]byte
+		ht    = crypto.Keccak256(target)
 		index int
 	)
 	for i, h := range t[0] {
-		if bytes.Equal(crypto.Keccak256(target), h) {
+		if bytes.Equal(ht, h) {
 			index = i
 		}
 	}
+
+	var proof [][]byte
 	for _, level := range t {
 		var i int
 		switch {

--- a/merkle/tree_test.go
+++ b/merkle/tree_test.go
@@ -88,3 +88,16 @@ func TestProof(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkProof(b *testing.B) {
+	var leaves [][]byte
+	for i := 0; i < 10000; i++ {
+		leaves = append(leaves, []byte{byte(i)})
+	}
+	mt := New(leaves)
+	for i := 0; i < b.N; i++ {
+		for _, l := range leaves {
+			mt.Proof(l)
+		}
+	}
+}


### PR DESCRIPTION
The target need only be hashed once.

Before: BenchmarkProof-10 1 53486735083 ns/op (53.486735083s)
After:  BenchmarkProof-10 4 299320958 ns/op (0.299320958s)