### PR TITLE
 ci: deploy whenever any go file is touched

### DIFF
--- a/.github/workflows/deploy-al-prod.yml
+++ b/.github/workflows/deploy-al-prod.yml
@@ -6,6 +6,7 @@ on:
       - "cmd/api/**"
       - "api/**"
       - ".github/**"
+      - "**.go"
 
 env:
   FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
 adds *.go to prod deploys.

 doing this because #32 was not deployed automatically