### PR TITLE
ci: remove foundry snapshot check

### DIFF
--- a/.github/workflows/contracts-test.yml
+++ b/.github/workflows/contracts-test.yml
@@ -36,11 +36,6 @@ jobs:
         id: build
         working-directory: ./contracts
 
-      - name: Run Forge snapshot
-        run: forge snapshot --check
-        id: snapshot
-        working-directory: ./contracts
-
       - name: Run tests
         run: forge test
         id: test


### PR DESCRIPTION
this check ends up being unstable as foundry is pinned to a nightly
version, causing ci failures unrelated to our code