### PR TITLE
api: store proofs on tree table

### DIFF
--- a/api/migrations/migrations.go
+++ b/api/migrations/migrations.go
@@ -42,4 +42,11 @@ var Migrations = []migrate.Migration{
 			CREATE UNIQUE INDEX on merkle_proofs(root, unhashed_leaf);
 		`,
 	},
+	{
+		Name: "2022-08-17.0.proofs.sql",
+		SQL: `
+			ALTER TABLE merkle_trees
+			ADD COLUMN proofs jsonb;
+		`,
+	},
 }

--- a/api/proof.go
+++ b/api/proof.go
@@ -41,6 +41,9 @@ func (s *Server) GetProof(w http.ResponseWriter, r *http.Request) {
 			proofs->'proof'
 		FROM tree
 		WHERE (
+			--eth addresses contain mixed casing to
+			--accommodate checksums. we sidestep
+			--the casing issues for user queries
 			lower(proofs->>'addr') = lower($2)
 			OR lower(proofs->>'leaf') = lower($3)
 		)

--- a/api/proof.go
+++ b/api/proof.go
@@ -16,13 +16,12 @@ type getProofResp struct {
 
 func (s *Server) GetProof(w http.ResponseWriter, r *http.Request) {
 	var (
-		ctx     = r.Context()
-		rootStr = r.URL.Query().Get("root")
-		root    = common.FromHex(rootStr)
-		leaf    = r.URL.Query().Get("unhashedLeaf")
-		addr    = r.URL.Query().Get("address")
+		ctx  = r.Context()
+		root = common.FromHex(r.URL.Query().Get("root"))
+		leaf = r.URL.Query().Get("unhashedLeaf")
+		addr = r.URL.Query().Get("address")
 	)
-	if rootStr == "" {
+	if len(root) == 0 {
 		s.sendJSONError(r, w, nil, http.StatusBadRequest, "missing root")
 		return
 	}
@@ -31,52 +30,32 @@ func (s *Server) GetProof(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	const q1 = `
-		SELECT 1
-		FROM merkle_trees
-		WHERE root = $1;
+	const q = `
+		WITH tree AS (
+			SELECT jsonb_array_elements(proofs) proofs
+			FROM merkle_trees
+			WHERE root = $1
+		)
+		SELECT
+			proofs->'leaf',
+			proofs->'proof'
+		FROM tree
+		WHERE (
+			lower(proofs->>'addr') = lower($2)
+			OR lower(proofs->>'leaf') = lower($3)
+		)
 	`
-	var empty int
-	err := s.db.QueryRow(ctx, q1, root).Scan(&empty)
+	var (
+		resp = &getProofResp{}
+		row  = s.db.QueryRow(ctx, q, root, addr, leaf)
+		err  = row.Scan(&resp.UnhashedLeaf, &resp.Proof)
+	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		s.sendJSONError(r, w, nil, http.StatusNotFound, "tree not found")
 		return
 	} else if err != nil {
-		s.sendJSONError(r, w, err, http.StatusInternalServerError, "failed to check tree exists")
+		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting proof")
 		return
-	}
-
-	resp := &getProofResp{}
-	if leaf != "" {
-		resp.UnhashedLeaf = common.FromHex(leaf)
-		const q2 = `
-			SELECT proof
-			FROM merkle_proofs
-			WHERE root = $1
-			AND unhashed_leaf = $2
-		`
-		row := s.db.QueryRow(ctx, q2, root, common.FromHex(leaf))
-		err = row.Scan(&resp.Proof)
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting proof for unhashedLeaf")
-			return
-		}
-	} else {
-		// since this isn't guaranteed to be unique,
-		// we take the first proof available
-		const q3 = `
-			SELECT proof, unhashed_leaf
-			FROM merkle_proofs
-			WHERE root = $1
-			AND address = $2
-			LIMIT 1
-		`
-		row := s.db.QueryRow(ctx, q3, root, common.HexToAddress(addr).Bytes())
-		err = row.Scan(&resp.Proof, &resp.UnhashedLeaf)
-		if err != nil && !errors.Is(err, pgx.ErrNoRows) {
-			s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting proof for address")
-			return
-		}
 	}
 
 	// cache for 1 year if we're returning an unhashed leaf proof

--- a/api/schema.sql
+++ b/api/schema.sql
@@ -29,7 +29,8 @@ CREATE TABLE public.merkle_trees (
     root bytea NOT NULL,
     unhashed_leaves bytea[] NOT NULL,
     ltd text[],
-    packed boolean
+    packed boolean,
+    proofs jsonb
 );
 
 

--- a/api/tree.go
+++ b/api/tree.go
@@ -1,11 +1,11 @@
 package api
 
 import (
+	"bytes"
+	"context"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/contextwtf/lanyard/merkle"
@@ -13,7 +13,89 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/rs/zerolog/log"
 )
+
+//TODO(ryan): remove this once the table has been updated
+func MigrateProofs(ctx context.Context, db *pgxpool.Pool) error {
+	const q1 = `
+		select root, unhashed_leaves, ltd, packed
+		from merkle_trees
+		where proofs is null
+	`
+	rows, err := db.Query(ctx, q1)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	//for the updates
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx) //noop for successful commit
+
+	var migrated int
+	for rows.Next() {
+		var (
+			tree   merkle.Tree
+			root   []byte
+			leaves [][]byte
+			ltd    []string
+			packed sql.NullBool
+		)
+		err = rows.Scan(&root, &leaves, &ltd, &packed)
+		if err != nil {
+			return err
+		}
+		tree = merkle.New(leaves)
+		if !bytes.Equal(root, tree.Root()) {
+			return errors.New("mismatched root")
+		}
+
+		type proofItem struct {
+			Leaf  string   `json:"leaf"`
+			Addr  string   `json:"addr"`
+			Proof []string `json:"proof"`
+		}
+		var proofs = []proofItem{}
+		for _, l := range leaves {
+			pf := tree.Proof(l)
+			if !merkle.Valid(tree.Root(), pf, l) {
+				return errors.New("invalid proof")
+			}
+			proofs = append(proofs, proofItem{
+				Leaf:  hexutil.Encode(l),
+				Addr:  leaf2Addr(l, ltd, packed.Bool).Hex(),
+				Proof: encodeProof(pf),
+			})
+		}
+
+		const q2 = `
+			update merkle_trees
+			set proofs = $1
+			where root = $2
+		`
+		_, err = tx.Exec(ctx, q2, proofs, root)
+		if err != nil {
+			return err
+		}
+		migrated++
+	}
+	if rows.Err() != nil {
+		return rows.Err()
+	}
+
+	err = tx.Commit(ctx)
+	if err != nil {
+		return err
+	}
+
+	log.Ctx(ctx).Info().Int("migrated", migrated).Msg("success")
+	return nil
+}
 
 func (s *Server) TreeHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
@@ -29,54 +111,51 @@ func (s *Server) TreeHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func leaf2AddrBytes(leaf []byte, ltd []string, packed bool) []byte {
+func leaf2Addr(leaf []byte, ltd []string, packed bool) common.Address {
 	if len(ltd) == 0 || (len(ltd) == 1 && ltd[0] == "address") {
-		return common.BytesToAddress(leaf).Bytes()
+		return common.BytesToAddress(leaf)
 	}
-
 	if packed {
 		return addrPacked(leaf, ltd)
 	}
 	return addrUnpacked(leaf, ltd)
 }
 
-func addrUnpacked(leaf []byte, ltd []string) []byte {
+func addrUnpacked(leaf []byte, ltd []string) common.Address {
 	var addrStart, pos int
 	for _, desc := range ltd {
 		if desc == "address" {
 			addrStart = pos
 			break
 		}
-
 		pos += 32
 	}
 	if len(leaf) >= addrStart+32 {
-		return common.BytesToAddress(leaf[addrStart:(addrStart + 32)]).Bytes()
+		return common.BytesToAddress(leaf[addrStart:(addrStart + 32)])
 	}
-	return nil
+	return common.Address{}
 }
 
-func addrPacked(leaf []byte, ltd []string) []byte {
+func addrPacked(leaf []byte, ltd []string) common.Address {
 	var addrStart, pos int
 	for _, desc := range ltd {
 		t, err := abi.NewType(desc, "", nil)
 		if err != nil {
-			return nil
+			return common.Address{}
 		}
 		if desc == "address" {
 			addrStart = pos
 			break
 		}
-
 		pos += int(t.GetType().Size())
 	}
 	if addrStart == 0 && pos != 0 {
-		return nil
+		return common.Address{}
 	}
 	if len(leaf) >= addrStart+20 {
-		return common.BytesToAddress(leaf[addrStart:(addrStart + 20)]).Bytes()
+		return common.BytesToAddress(leaf[addrStart:(addrStart + 20)])
 	}
-	return nil
+	return common.Address{}
 }
 
 type jsonNullBool struct {
@@ -105,6 +184,14 @@ func (jnb jsonNullBool) MarshalJSON() ([]byte, error) {
 	return json.Marshal(nil)
 }
 
+func encodeProof(p [][]byte) []string {
+	var res []string
+	for i := range p {
+		res = append(res, hexutil.Encode(p[i]))
+	}
+	return res
+}
+
 type createTreeReq struct {
 	Leaves []hexutil.Bytes `json:"unhashedLeaves"`
 	Ltd    []string        `json:"leafTypeDescriptor"`
@@ -125,81 +212,64 @@ func (s *Server) CreateTree(w http.ResponseWriter, r *http.Request) {
 		s.sendJSONError(r, w, err, http.StatusBadRequest, "unhashedLeaves must be a list of hex strings")
 		return
 	}
-	if len(req.Leaves) == 0 {
+	switch len(req.Leaves) {
+	case 0:
 		s.sendJSONError(r, w, nil, http.StatusBadRequest, "No leaves provided")
 		return
-	}
-	if len(req.Leaves) == 1 {
+	case 1:
 		s.sendJSONError(r, w, nil, http.StatusBadRequest, "You must provide at least two values")
 		return
 	}
 
-	dbtx, err := s.db.Begin(ctx)
-	defer dbtx.Rollback(ctx)
-	if err != nil {
-		s.sendJSONError(r, w, err, http.StatusInternalServerError, "Failed to start transaction")
-		return
-	}
-
+	//convert []hexutil.Bytes to [][]byte
 	var leaves [][]byte
 	for i := range req.Leaves {
 		leaves = append(leaves, req.Leaves[i])
 	}
 	tree := merkle.New(leaves)
-	const q1 = `
-		INSERT INTO merkle_trees (root, unhashed_leaves, ltd, packed)
-		VALUES ($1, $2, $3, $4)
+
+	type proofItem struct {
+		Leaf  string   `json:"leaf"`
+		Addr  string   `json:"addr"`
+		Proof []string `json:"proof"`
+	}
+	var proofs = []proofItem{}
+	for _, l := range req.Leaves {
+		pf := tree.Proof(l)
+		if !merkle.Valid(tree.Root(), pf, l) {
+			s.sendJSONError(r, w, nil, http.StatusBadRequest, "Unable to generate proof for tree")
+			return
+		}
+		proofs = append(proofs, proofItem{
+			Leaf:  hexutil.Encode(l),
+			Addr:  leaf2Addr(l, req.Ltd, req.Packed.Bool).Hex(),
+			Proof: encodeProof(pf),
+		})
+	}
+	const q = `
+		INSERT INTO merkle_trees(
+			root,
+			unhashed_leaves,
+			ltd,
+			packed,
+			proofs
+		) VALUES ($1, $2, $3, $4, $5)
 		ON CONFLICT (root)
 		DO NOTHING
 	`
-	_, err = dbtx.Exec(ctx, q1, tree.Root(), leaves, req.Ltd, req.Packed)
+	_, err := s.db.Exec(ctx, q,
+		tree.Root(),
+		req.Leaves,
+		req.Ltd,
+		req.Packed.NullBool,
+		proofs,
+	)
 	if err != nil {
-		s.sendJSONError(r, w, err, http.StatusInternalServerError, "Failed to insert merkle tree")
+		s.sendJSONError(r, w, err, http.StatusInternalServerError, "inserting tree")
 		return
 	}
 
-	var batch = &pgx.Batch{}
-	for _, leaf := range leaves {
-		proof := tree.Proof(leaf)
-		if len(proof) == 0 {
-			s.sendJSONError(r, w, nil, http.StatusBadRequest, "Must provide addresses that result in a proof")
-			return
-		}
-		const q2 = `
-			INSERT INTO merkle_proofs (root, unhashed_leaf, address, proof)
-			VALUES ($1, $2, $3, $4)
-			ON CONFLICT (root, unhashed_leaf)
-			DO NOTHING;
-		`
-		batch.Queue(q2,
-			tree.Root(),
-			leaf,
-			leaf2AddrBytes(leaf, req.Ltd, req.Packed.Bool),
-			proof,
-		)
-	}
-	br := dbtx.SendBatch(ctx, batch)
-	for i := 0; i < len(leaves); i++ {
-		_, err := br.Exec()
-		if err != nil {
-			s.sendJSONError(r, w, err, http.StatusInternalServerError, "inserting proofs")
-			return
-		}
-	}
-	err = br.Close()
-	if err != nil {
-		s.sendJSONError(r, w, err, http.StatusInternalServerError, "inserting proof batch")
-		return
-	}
-
-	err = dbtx.Commit(ctx)
-	if err != nil {
-		s.sendJSONError(r, w, err, http.StatusInternalServerError, "committing tx")
-		return
-	}
-	s.sendJSON(r, w, createTreeResp{
-		MerkleRoot: fmt.Sprintf("0x%s", hex.EncodeToString(tree.Root())),
-	})
+	s.sendJSON(r, w, createTreeResp{hexutil.Encode(tree.Root())})
 }
 
 type getTreeResp struct {

--- a/api/tree_test.go
+++ b/api/tree_test.go
@@ -4,31 +4,30 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 )
 
 func TestAddrUnpacked(t *testing.T) {
 	cases := []struct {
 		leaf []byte
 		ltd  []string
-		want string
+		want common.Address
 	}{
 		{
 			common.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"),
 			[]string{"uint32", "address"},
-			"0x0000000000000000000000000000000000000001",
+			common.HexToAddress("0x0000000000000000000000000000000000000001"),
 		},
 		{
 			common.Hex2Bytes("00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000"),
 			[]string{"address", "uint32"},
-			"0x0000000000000000000000000000000000000001",
+			common.HexToAddress("0x0000000000000000000000000000000000000001"),
 		},
 	}
 
 	for _, c := range cases {
-		res := addrUnpacked(c.leaf, c.ltd)
-		if hexutil.Encode(res) != c.want {
-			t.Errorf("expected: %v got: %v", "0xaa...", hexutil.Encode(res))
+		addr := addrUnpacked(c.leaf, c.ltd)
+		if addr != c.want {
+			t.Errorf("expected: %v got: %v", c.want, addr)
 		}
 	}
 }
@@ -37,24 +36,24 @@ func TestAddrPacked(t *testing.T) {
 	cases := []struct {
 		leaf []byte
 		ltd  []string
-		want string
+		want common.Address
 	}{
 		{
 			common.Hex2Bytes("000000000000000000000000000000000000000000000001"),
 			[]string{"uint32", "address"},
-			"0x0000000000000000000000000000000000000001",
+			common.HexToAddress("0x0000000000000000000000000000000000000001"),
 		},
 		{
 			common.Hex2Bytes("000000000000000000000000000000000000000100000000"),
 			[]string{"address", "uint32"},
-			"0x0000000000000000000000000000000000000001",
+			common.HexToAddress("0x0000000000000000000000000000000000000001"),
 		},
 	}
 
 	for _, c := range cases {
-		res := addrPacked(c.leaf, c.ltd)
-		if hexutil.Encode(res) != c.want {
-			t.Errorf("expected: %v got: %v", c.want, hexutil.Encode(res))
+		addr := addrPacked(c.leaf, c.ltd)
+		if addr != c.want {
+			t.Errorf("expected: %v got: %v", c.want, addr)
 		}
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -90,6 +90,8 @@ func main() {
 
 	s := api.New(db)
 
+	check(api.MigrateProofs(ctx, db))
+
 	const defaultListen = ":8080"
 	listen := os.Getenv("LISTEN")
 	if listen == "" {


### PR DESCRIPTION
I don't think it is necessary to store the pre-computed proofs for a
tree in a separate table. In fact, the two tables design yields N
queries for a tree with N leaves. These queries are currently batched,
but I believe we can avoid the work altogether.

I did notice that the current code dealt with duplicate leaves by
selecting the first found proof. On further inspection, it's unclear
what behaviour we should exhibit on duplicate keys. We may want to
return an error on tree creation if we detect duplicate leaves.