### PR TITLE
api: set up global tracer if DD_AGENT_HOST is set

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/contextwtf/lanyard/api/tracing"
+
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/rs/cors"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/hlog"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 type Server struct {
@@ -64,7 +65,8 @@ func versionHandler(h http.Handler, sha string) http.Handler {
 
 func tracingHandler(env, sha string, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		span, ctx := tracer.StartSpanFromContext(r.Context(), fmt.Sprintf("req.%s", r.URL.Path))
+		span, ctx := tracing.SpanFromContext(r.Context(), "http.request")
+
 		defer span.Finish()
 
 		log := zerolog.Ctx(r.Context())

--- a/api/tracing/main.go
+++ b/api/tracing/main.go
@@ -1,0 +1,72 @@
+package tracing
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v4"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+)
+
+func getQueryName(query string) (name string) {
+	lines := strings.SplitN(query, "\n", 1)
+	name = "pgx"
+	if len(lines) > 0 {
+		first := lines[0]
+		params := strings.SplitN(first, ":", 3)
+		if len(params) > 1 {
+			name += "." + strings.TrimSpace(params[1])
+		}
+	}
+
+	return name
+}
+
+func SpanFromContext(ctx context.Context, name string, opts ...tracer.StartSpanOption) (ddtrace.Span, context.Context) {
+	parent, ok := tracer.SpanFromContext(ctx)
+	if !ok {
+		return tracer.StartSpanFromContext(ctx, name, opts...)
+	}
+
+	optsWithChild := []tracer.StartSpanOption{tracer.ChildOf(parent.Context())}
+	optsWithChild = append(optsWithChild, opts...)
+	span := tracer.StartSpan(
+		name,
+		optsWithChild...,
+	)
+
+	return span, tracer.ContextWithSpan(ctx, span)
+}
+
+type DBTracer struct {
+	serviceName string
+}
+
+func NewDBTracer(serviceName string) *DBTracer {
+	return &DBTracer{
+		serviceName: serviceName,
+	}
+}
+
+func (l *DBTracer) Log(ctx context.Context, level pgx.LogLevel, msg string, data map[string]any) {
+	t, timeOk := data["time"].(time.Duration)
+	q, queryOk := data["sql"].(string)
+	if timeOk && queryOk {
+		end := time.Now()
+		start := end.Add(-t)
+		startTime := tracer.StartTime(start)
+
+		opts := []ddtrace.StartSpanOption{
+			tracer.SpanType(ext.SpanTypeSQL),
+			tracer.ResourceName(string(q)),
+			tracer.ServiceName(l.serviceName),
+			startTime,
+		}
+
+		span, _ := SpanFromContext(ctx, getQueryName(q), opts...)
+		span.Finish(tracer.FinishTime(end))
+	}
+}

--- a/cmd/api/deploy.sh
+++ b/cmd/api/deploy.sh
@@ -14,4 +14,9 @@ go run github.com/tailscale/mkctr@latest \
   --push \
 /usr/local/bin/api
 
-flyctl deploy --detach -i registry.fly.io/al-prod:latest -a al-prod
+flyctl deploy --detach \
+	-i registry.fly.io/al-prod:latest \
+	-a al-prod \
+	-e "DD_ENV=production" \
+	-e "DD_SERVICE=al-prod" \
+	-e "DD_AGENT_HOST=datadog-agent.internal"

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -72,9 +72,9 @@ func main() {
 		dbc.ConnConfig.Logger = tracing.NewDBTracer(
 			dbc.ConnConfig.Host,
 		)
+		dbc.ConnConfig.LogLevel = pgx.LogLevelTrace
 	}
 
-	dbc.ConnConfig.LogLevel = pgx.LogLevelTrace
 	dbc.MaxConns = 20
 	db, err := pgxpool.ConnectConfig(ctx, dbc)
 	check(err)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.21
 	github.com/jackc/pgx/v4 v4.16.1
 	github.com/lib/pq v1.10.5
+	github.com/opentracing/opentracing-go v1.2.0
 	github.com/rs/cors v1.8.2
 	github.com/rs/zerolog v1.27.0
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c


### PR DESCRIPTION
while we do have tracing set up for some logs, traces aren't currently being sent as the global tracer is not initialized. this adds that

also adds tracing of every db query