### PR TITLE
api: remove tree/proofs migration

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -90,8 +90,6 @@ func main() {
 
 	s := api.New(db)
 
-	check(api.MigrateProofs(ctx, db))
-
 	const defaultListen = ":8080"
 	listen := os.Getenv("LISTEN")
 	if listen == "" {


### PR DESCRIPTION
Output from our server on last deploy:
```
{
        "level":"info",
        "migrated":242,
        "time":1660854862,
        "caller":"github.com/contextwtf/lanyard/api/tree.go:96",
        "message":"success"
}
```