### PR TITLE
api,www: add endpoint for fetching a root from a given proof

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -30,6 +30,7 @@ func (s *Server) Handler(env, gitSha string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/tree", s.TreeHandler)
 	mux.HandleFunc("/api/v1/proof", s.GetProof)
+	mux.HandleFunc("/api/v1/root", s.GetRoot)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprint(w, gitSha)
 	})

--- a/api/migrations/migrations.go
+++ b/api/migrations/migrations.go
@@ -61,4 +61,10 @@ var Migrations = []migrate.Migration{
 			ALTER TABLE merkle_trees RENAME TO trees;
 		`,
 	},
+	{
+		Name: "2022-08-22.0.add-proof-idx.sql",
+		SQL: `
+		    CREATE INDEX on trees USING gin(proofs jsonb_path_ops);
+		`,
+	},
 }

--- a/api/root.go
+++ b/api/root.go
@@ -10,11 +10,11 @@ import (
 	"github.com/jackc/pgx/v4"
 )
 
-type proofLookup struct {
-	Proof []string `json:"proof"`
-}
-
 func proofURLToDBQuery(param string) string {
+	type proofLookup struct {
+		Proof []string `json:"proof"`
+	}
+
 	lookup := proofLookup{
 		Proof: strings.Split(param, ","),
 	}
@@ -27,11 +27,11 @@ func proofURLToDBQuery(param string) string {
 	return string(q)
 }
 
-type rootResp struct {
-	Root hexutil.Bytes `json:"root"`
-}
-
 func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
+	type rootResp struct {
+		Root hexutil.Bytes `json:"root"`
+	}
+
 	var (
 		ctx     = r.Context()
 		proof   = r.URL.Query().Get("proof")
@@ -42,7 +42,7 @@ func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	q := `
+	const q = `
 		SELECT root
 		FROM trees
 		WHERE proofs @> $1

--- a/api/root.go
+++ b/api/root.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/jackc/pgx/v4"
+)
+
+type proofLookup struct {
+	Proof []string `json:"proof"`
+}
+
+func proofURLToDBQuery(param string) string {
+	lookup := proofLookup{
+		Proof: strings.Split(param, ","),
+	}
+
+	q, err := json.Marshal([]proofLookup{lookup})
+	if err != nil {
+		return ""
+	}
+
+	return string(q)
+}
+
+type rootResp struct {
+	Root hexutil.Bytes `json:"root"`
+}
+
+func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
+	var (
+		ctx     = r.Context()
+		proof   = r.URL.Query().Get("proof")
+		dbQuery = proofURLToDBQuery(proof)
+	)
+	if proof == "" || dbQuery == "" {
+		s.sendJSONError(r, w, nil, http.StatusBadRequest, "missing list of proofs")
+		return
+	}
+
+	q := `
+		SELECT root
+		FROM trees
+		WHERE proofs @> $1
+		LIMIT 1
+	`
+
+	rr := rootResp{}
+	err := s.db.QueryRow(ctx, q, dbQuery).Scan(
+		&rr.Root,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		s.sendJSONError(r, w, err, http.StatusNotFound, "root not found for proofs")
+		return
+	} else if err != nil {
+		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting root")
+		return
+	}
+
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	s.sendJSON(r, w, rr)
+}

--- a/example/src/api.ts
+++ b/example/src/api.ts
@@ -80,6 +80,12 @@ const getProofForIndexedAddress = async (
   return await proofRes.json()
 }
 
+const getRootFromProof = async (proof: string[]): Promise<string> => {
+  const rootRes = await fetch(`${baseUrl}/api/v1/root?proof=${proof.join(',')}`)
+  const resp = await rootRes.json()
+  return resp.root
+}
+
 const encode = utils.defaultAbiCoder.encode.bind(utils.defaultAbiCoder)
 const encodePacked = utils.solidityPack
 
@@ -236,3 +242,7 @@ checkProofEquality(
     utils.keccak256(encodedPackedLeafData[0]),
   ),
 )
+
+const root = await getRootFromProof(encodedPackedProof)
+console.log('root from proof', root)
+checkRootEquality(root, encodedPackedMerkleRoot)

--- a/www/components/Docs/codeSnippets.ts
+++ b/www/components/Docs/codeSnippets.ts
@@ -49,3 +49,13 @@ GET https://lanyard.build/api/v1/proof?root={root}&unhashedLeaf={unhashedLeaf}
   "unhashedLeaf": "0x0000000000000000000000000000000000000003" // or null if not in the tree
 }
 `.trim()
+
+export const rootCode = `
+// proof is 0x prefixed, comma separated values
+GET https://lanyard.build/api/v1/root?proof={proof}
+
+// Response body
+{
+  "root": "0x0000000000000000000000000000000000000003" // returns error if not found
+}
+`.trim()

--- a/www/components/Docs/index.tsx
+++ b/www/components/Docs/index.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link'
 import { brandUnderlineClasses } from 'utils/theme'
 import PageTitle from 'components/PageTitle'
 import CodeBlock from 'components/CodeBlock'
-import { createCode, lookupCode, proofCode } from './codeSnippets'
+import { createCode, lookupCode, proofCode, rootCode } from './codeSnippets'
 import Section from './Section'
 
 export default function Docs() {
@@ -41,6 +41,12 @@ export default function Docs() {
           description="Typically the unhashed leaf value will be an address."
         >
           <CodeBlock code={proofCode} language="javascript" />
+        </Section>
+        <Section
+          title="Looking up a root for a given proof"
+          description="A more advanced use but helpful if you just have a proof."
+        >
+          <CodeBlock code={rootCode} language="javascript" />
         </Section>
       </div>
     </div>


### PR DESCRIPTION
adds `/api/v1/root`, an endpoint that returns a root
if the proofs are found in the lanyard system.

updated docs and the test script for new endpoint