### PR TITLE
api: add `inserted_at` to trees table

### DIFF
--- a/api/migrations/migrations.go
+++ b/api/migrations/migrations.go
@@ -67,4 +67,11 @@ var Migrations = []migrate.Migration{
 		    CREATE INDEX on trees USING gin(proofs jsonb_path_ops);
 		`,
 	},
+	{
+		Name: "2022-08-22.0.add-inserted-at.sql",
+		SQL: `
+		ALTER TABLE trees 
+		ADD COLUMN "inserted_at" timestamptz NOT NULL DEFAULT now();
+		`,
+	},
 }

--- a/api/migrations/migrations.go
+++ b/api/migrations/migrations.go
@@ -68,7 +68,7 @@ var Migrations = []migrate.Migration{
 		`,
 	},
 	{
-		Name: "2022-08-22.0.add-inserted-at.sql",
+		Name: "2022-08-22.1.add-inserted-at.sql",
 		SQL: `
 		ALTER TABLE trees 
 		ADD COLUMN "inserted_at" timestamptz NOT NULL DEFAULT now();


### PR DESCRIPTION
adds an `inserted_at` column to trees. will be useful for
analytics / understanding how people use lanyard