### PR TITLE
api,www: add duplicate detection and correction

### DIFF
--- a/api/tree.go
+++ b/api/tree.go
@@ -138,22 +138,18 @@ func (s *Server) CreateTree(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var (
-		leaves [][]byte
-		// used to check if there are duplicate leaves in request
-		vals map[string]struct{} = map[string]struct{}{}
+		leaves       [][]byte
+		uniqueLeaves = map[string]struct{}{}
 	)
-
-	//convert []hexutil.Bytes to [][]byte
-	for i := range req.Leaves {
-		leaves = append(leaves, req.Leaves[i])
-		str := req.Leaves[i].String()
-		_, isDuplicate := vals[str]
-		if isDuplicate {
-			// error, duplicate value
+	for _, l := range req.Leaves {
+		_, dupe := uniqueLeaves[l.String()]
+		if dupe {
 			s.sendJSONError(r, w, nil, http.StatusBadRequest, "Duplicate value found in unhashedLeaves. Please remove duplicates and re-send.")
 			return
 		}
-		vals[str] = struct{}{}
+		uniqueLeaves[l.String()] = struct{}{}
+		//convert slice of hexutil.Bytes to a slice of bytes
+		leaves = append(leaves, l)
 	}
 
 	tree := merkle.New(leaves)

--- a/api/tree.go
+++ b/api/tree.go
@@ -150,7 +150,7 @@ func (s *Server) CreateTree(w http.ResponseWriter, r *http.Request) {
 		_, isDuplicate := vals[str]
 		if isDuplicate {
 			// error, duplicate value
-			s.sendJSONError(r, w, nil, http.StatusBadRequest, "Duplicate value found in tree")
+			s.sendJSONError(r, w, nil, http.StatusBadRequest, "Duplicate value found in unhashedLeaves. Please remove duplicates and re-send.")
 			return
 		}
 		vals[str] = struct{}{}

--- a/example/src/api.ts
+++ b/example/src/api.ts
@@ -7,7 +7,7 @@ const createTree = async (
   unhashedLeaves: string[],
   leafTypeDescriptor?: string[],
   packedEncoding?: boolean,
-): Promise<{ merkleRoot: string }> => {
+): Promise<{ merkleRoot: string; error?: boolean }> => {
   const encodedTreeRes = await fetch(`${baseUrl}/api/v1/tree`, {
     method: 'POST',
     headers: {
@@ -138,6 +138,21 @@ const { merkleRoot: basicMerkleRoot } = await createTree(unhashedLeaves)
 
 console.log('basic merkle root', basicMerkleRoot)
 checkRootEquality(basicMerkleRoot, makeMerkleTree(unhashedLeaves).getHexRoot())
+
+// basic merkle tree
+const duplicateUnhashedLeaves = [
+  '0x0000000000000000000000000000000000000001',
+  '0x0000000000000000000000000000000000000001',
+  '0x0000000000000000000000000000000000000003',
+  '0x0000000000000000000000000000000000000004',
+  '',
+]
+
+const { error } = await createTree(duplicateUnhashedLeaves)
+if (!error) {
+  throw new Error('Expected error when creating tree with duplicate leaves')
+}
+console.log('successfully received error for duplicate leaves')
 
 const basicTree = await getTree(basicMerkleRoot)
 console.log('basic leaf count', basicTree.leafCount)

--- a/www/components/CreateRoot.tsx
+++ b/www/components/CreateRoot.tsx
@@ -69,7 +69,7 @@ export default function CreateRoot() {
       return []
     }
 
-    return parseAddressesFromText(addressInput).addresses
+    return parseAddressesFromText(addressInput, false).addresses
   }, [addressInput])
 
   const parsedAddressesCount = useMemo(

--- a/www/components/CreateRoot.tsx
+++ b/www/components/CreateRoot.tsx
@@ -35,23 +35,41 @@ export default function CreateRoot() {
     status,
     create,
   } = useCreateMerkleRoot()
+  const [hasDuplicatesErr, setHasDuplicates] = useState(false)
   const [addressInput, addressInputSet] = useState('')
+
+  useEffect(() => {
+    setHasDuplicates(false)
+  }, [addressInput])
 
   const handleSubmit = useCallback(() => {
     if (addressInput.trim().length === 0) {
       return
     }
 
-    const addresses = parseAddressesFromText(addressInput)
+    const { addresses, hasDuplicates } = parseAddressesFromText(
+      addressInput,
+      false,
+    )
+    if (hasDuplicates) {
+      setHasDuplicates(true)
+      return
+    }
+
     create(addresses)
   }, [addressInput, create])
+
+  const removeDuplicates = () => {
+    const { addresses } = parseAddressesFromText(addressInput, true)
+    addressInputSet(addresses.join('\n'))
+  }
 
   const parsedAddresses = useMemo(() => {
     if (addressInput.trim().length === 0) {
       return []
     }
 
-    return parseAddressesFromText(addressInput)
+    return parseAddressesFromText(addressInput).addresses
   }, [addressInput])
 
   const parsedAddressesCount = useMemo(
@@ -121,6 +139,18 @@ export default function CreateRoot() {
       {status === 'success' && errorResponse !== undefined && (
         <div className="text-center sm:text-left w-full">
           Error: {errorResponse.message}
+        </div>
+      )}
+
+      {hasDuplicatesErr && (
+        <div className="text-center text-red-500 sm:text-left w-full">
+          List contains duplicates. Remove duplicates manually or{' '}
+          <button
+            className="cursor-pointer border-b-2 border-red-500"
+            onClick={() => removeDuplicates()}
+          >
+            click here to remove duplicates.
+          </button>
         </div>
       )}
     </div>

--- a/www/utils/addressParsing.ts
+++ b/www/utils/addressParsing.ts
@@ -1,8 +1,35 @@
-export function parseAddressesFromText(text: string) {
+export function parseAddressesFromText(
+  text: string,
+  removeDuplicates: boolean,
+): {
+  addresses: string[]
+  hasDuplicates: boolean
+} {
+  let hasDuplicates = false
+
+  let addrs: { [key: string]: boolean } = {}
+
   // split the addresses by comma, space, or newline
   // and trim each one
-  return text
-    .split(/[,\s\n]+/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
+  return {
+    addresses: text
+      .split(/[,\s\n]+/)
+      .map((s) => {
+        let a = s.trim().toLowerCase()
+
+        if (addrs[a]) {
+          if (removeDuplicates) {
+            return ''
+          }
+
+          hasDuplicates = true
+        }
+
+        addrs[a] = true
+
+        return a
+      })
+      .filter((s) => s.length > 0),
+    hasDuplicates,
+  }
 }


### PR DESCRIPTION
duplicate addresses causes the merkle root to be different, causing subtle bugs in behavior.

this pull request attempts to address this problem by:
- updating the api to error when duplicate addresses are detected
- adding a check to the test suite for an error on this case
- updating the www frontend to not send lists with duplicated addresses and providing a 1-click solution that removes duplicates

resolves #50