### PR TITLE
api: add a log for each request

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -46,7 +46,7 @@ func (s *Server) Handler(env, gitSha string) http.Handler {
 	h = hlog.URLHandler("path")(h)
 	h = tracingHandler(os.Getenv("DD_ENV"), os.Getenv("DD_SERVICE"), gitSha, h)
 	h = RemoteAddrHandler("ip")(h)
-	h = hlog.NewHandler(log.Logger)(h)
+	h = hlog.NewHandler(log.Logger)(h) // needs to be last for log values to correctly be passed to context
 
 	if env == "production" {
 		return h

--- a/api/api.go
+++ b/api/api.go
@@ -44,6 +44,7 @@ func (s *Server) Handler(env, gitSha string) http.Handler {
 	h = hlog.RefererHandler("referer")(h)
 	h = hlog.RequestIDHandler("req_id", "Request-Id")(h)
 	h = hlog.URLHandler("path")(h)
+	h = hlog.MethodHandler("method")(h)
 	h = tracingHandler(os.Getenv("DD_ENV"), os.Getenv("DD_SERVICE"), gitSha, h)
 	h = RemoteAddrHandler("ip")(h)
 	h = hlog.NewHandler(log.Logger)(h) // needs to be last for log values to correctly be passed to context
@@ -136,7 +137,6 @@ func tracingHandler(env, service, sha string, h http.Handler) http.Handler {
 
 		// log every request
 		log.Info().
-			Str("method", r.Method).
 			Int("status", sc.status).
 			Dur("duration", time.Since(requestStart)).
 			Msg("")

--- a/api/api.go
+++ b/api/api.go
@@ -134,13 +134,11 @@ func tracingHandler(env, service, sha string, h http.Handler) http.Handler {
 		requestStart := time.Now()
 		h.ServeHTTP(sc, r.WithContext(ctx))
 
-		duration := time.Since(requestStart)
-
 		// log every request
 		log.Info().
 			Str("method", r.Method).
 			Int("status", sc.status).
-			Dur("duration", duration).
+			Dur("duration", time.Since(requestStart)).
 			Msg("")
 
 		span.SetTag(ext.HTTPCode, sc.status)

--- a/api/api.go
+++ b/api/api.go
@@ -113,18 +113,14 @@ func tracingHandler(env, service, sha string, h http.Handler) http.Handler {
 		defer span.Finish()
 		log := zerolog.Ctx(ctx)
 
-		log.UpdateContext(func(c zerolog.Context) zerolog.Context {
-			return c.Uint64("dd.trace_id", span.Context().TraceID())
-		})
-		log.UpdateContext(func(c zerolog.Context) zerolog.Context {
-			return c.Str("dd.service", service)
-		})
-		log.UpdateContext(func(c zerolog.Context) zerolog.Context {
-			return c.Str("dd.env", env)
-		})
-		log.UpdateContext(func(c zerolog.Context) zerolog.Context {
-			return c.Str("dd.version", sha)
-		})
+		if env != "" {
+			log.UpdateContext(func(c zerolog.Context) zerolog.Context {
+				return c.Uint64("dd.trace_id", span.Context().TraceID()).
+					Str("dd.service", service).
+					Str("dd.env", env).
+					Str("dd.version", sha)
+			})
+		}
 
 		span.SetTag(ext.ResourceName, r.URL.Path)
 		span.SetTag(ext.SpanType, ext.SpanTypeWeb)


### PR DESCRIPTION
adds a log for each request to make lanyard easier to operate - also allows to aid with debugging by adding a way to look up request IDs in log output