### PR TITLE
misc: rename lanyard.build -> lanyard.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Create an allow list in seconds that works across web3
 
-[lanyard.build](https://lanyard.build)
+[lanyard.org](https://lanyard.org)

--- a/merkle/tree.go
+++ b/merkle/tree.go
@@ -1,4 +1,4 @@
-// A merkle tree for [lanyard.build].
+// A merkle tree for [lanyard.org].
 // merkle uses keccak256 hashing for leaves
 // and intermediary nodes and therefore is vulnerable to a
 // second preimage attack. This package does not duplicate or pad leaves in
@@ -7,7 +7,7 @@
 // see the following [bitcoin issue].
 //
 // [bitcoin issue]: https://bitcointalk.org/index.php?topic=102395.0
-// [lanyard.build]: https://lanyard.build
+// [lanyard.org]: https://lanyard.org
 package merkle
 
 import (

--- a/www/.env
+++ b/www/.env
@@ -1,1 +1,1 @@
-API_URL=https://lanyard.build
+API_URL=https://lanyard.org

--- a/www/components/Docs/codeSnippets.ts
+++ b/www/components/Docs/codeSnippets.ts
@@ -1,5 +1,5 @@
 export const createCode = `
-POST https://lanyard.build/api/v1/tree
+POST https://lanyard.org/api/v1/tree
 
 // Request body
 {
@@ -21,7 +21,7 @@ POST https://lanyard.build/api/v1/tree
 `.trim()
 
 export const lookupCode = `
-GET https://lanyard.build/api/v1/tree?root={root}
+GET https://lanyard.org/api/v1/tree?root={root}
 
 // Response body
 {
@@ -38,7 +38,7 @@ GET https://lanyard.build/api/v1/tree?root={root}
 `.trim()
 
 export const proofCode = `
-GET https://lanyard.build/api/v1/proof?root={root}&unhashedLeaf={unhashedLeaf}
+GET https://lanyard.org/api/v1/proof?root={root}&unhashedLeaf={unhashedLeaf}
 
 // Response body
 {
@@ -52,7 +52,7 @@ GET https://lanyard.build/api/v1/proof?root={root}&unhashedLeaf={unhashedLeaf}
 
 export const rootCode = `
 // proof is 0x prefixed, comma separated values
-GET https://lanyard.build/api/v1/root?proof={proof}
+GET https://lanyard.org/api/v1/root?proof={proof}
 
 // Response body
 {

--- a/www/components/Layout/index.tsx
+++ b/www/components/Layout/index.tsx
@@ -14,7 +14,7 @@ export default function Layout({ children }: Props) {
       <MetaTags
         description={siteDescription}
         // og:image spec requires full url, can't use path for image
-        imageUrl="https://lanyard.build/meta-image.png"
+        imageUrl="https://lanyard.org/meta-image.png"
       />
       <Head />
 


### PR DESCRIPTION
we own lanyard.org now! awesome. let's merge this in the morning to give dns some time to propagate.