### PR TITLE
add PUT /api/v1/tree/pin endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -21,17 +21,22 @@ import (
 
 type Server struct {
 	db *pgxpool.Pool
+	hc *http.Client
 }
 
 func New(db *pgxpool.Pool) *Server {
 	return &Server{
 		db: db,
+		hc: &http.Client{
+			Timeout: time.Second * 10,
+		},
 	}
 }
 
 func (s *Server) Handler(env, gitSha string) http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/tree", s.TreeHandler)
+	mux.HandleFunc("/api/v1/tree/pin", s.PinTree)
 	mux.HandleFunc("/api/v1/proof", s.GetProof)
 	mux.HandleFunc("/api/v1/root", s.GetRoot)
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/api/ipfs.go
+++ b/api/ipfs.go
@@ -1,0 +1,88 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+var (
+	ipfsPinningServiceURL = os.Getenv("IPFS_PINNING_SERVICE_URL")
+	ipfsPinningSecret     = os.Getenv("IPFS_PINNING_SECRET")
+)
+
+func (s *Server) pinTree(ctx context.Context, root hexutil.Bytes) (string, error) {
+	if ipfsPinningServiceURL == "" {
+		return "", errors.New("error: IPFS_PINNING_SERVICE_URL not set")
+	}
+
+	const q = `
+		SELECT unhashed_leaves, ltd, packed
+		FROM trees
+		WHERE root = $1
+	`
+	tr := struct {
+		Root           hexutil.Bytes   `json:"root"`
+		UnhashedLeaves []hexutil.Bytes `json:"unhashedLeaves"`
+		Ltd            []string        `json:"leafTypeDescriptor"`
+		Packed         jsonNullBool    `json:"packedEncoding"`
+	}{
+		Root: root,
+	}
+
+	err := s.db.QueryRow(ctx, q, root).Scan(
+		&tr.UnhashedLeaves,
+		&tr.Ltd,
+		&tr.Packed,
+	)
+
+	if err != nil {
+		return "", err
+	}
+
+	msg, err := json.Marshal(tr)
+
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequestWithContext(
+		ctx, "POST", ipfsPinningServiceURL, bytes.NewReader(msg),
+	)
+
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+ipfsPinningSecret)
+	req.Header.Set("Content-Type", "application/json")
+
+	res, err := s.hc.Do(req)
+
+	if err != nil {
+		return "", err
+	}
+
+	if res.StatusCode >= 400 {
+		return "", errors.New(res.Status)
+	}
+
+	type resp struct {
+		Hash string `json:"IpfsHash"`
+	}
+
+	defer res.Body.Close()
+
+	var r resp
+	err = json.NewDecoder(res.Body).Decode(&r)
+	if err != nil {
+		return "", err
+	}
+
+	return r.Hash, nil
+}


### PR DESCRIPTION
this is a draft attempt at adding a /api/v1/tree/pin endpoint.

this endpoint will pin a json representation of a merkle tree to
ipfs. you can see an example of what this code currently produces
pinned to `[ipfs://QmXdDyUSsM59MUoeZyDS5uVo8gg4WMenduvehUjP4Hs8KG](https://cloudflare-ipfs.com/ipfs/QmXdDyUSsM59MUoeZyDS5uVo8gg4WMenduvehUjP4Hs8KG)`.

open ideas/questions:

- should we save ipfs hashes to postgres when we pin them and
return them via `/tree` and other endpoints?

- should we save every tree by default to IPFS? if we do that,
how do we depend on our pinning provider being down/retries/etc. also
the latency isn't great as is - even locally pinning was taking 600ms-1s