### PR TITLE
api: make trees.packed not null

### DIFF
--- a/api/migrations/migrations.go
+++ b/api/migrations/migrations.go
@@ -70,8 +70,19 @@ var Migrations = []migrate.Migration{
 	{
 		Name: "2022-08-22.1.add-inserted-at.sql",
 		SQL: `
-		ALTER TABLE trees 
+		ALTER TABLE trees
 		ADD COLUMN "inserted_at" timestamptz NOT NULL DEFAULT now();
+		`,
+	},
+	{
+		Name: "2022-08-30.0.packed-bool.sql",
+		SQL: `
+		UPDATE trees SET packed = true
+		WHERE packed IS NULL;
+
+		ALTER TABLE trees
+		ALTER COLUMN packed
+		SET NOT NULL;
 		`,
 	},
 }


### PR DESCRIPTION
Booleans with 3 possible values are needlessly confusing.

Unpacked data is padded to 32 bytes. Most of the time, callers will
provide a list of [20]byte values (ETH addresses)  --which is packed.