### PR TITLE
docs: remove null reference

### DIFF
--- a/www/components/Docs/codeSnippets.ts
+++ b/www/components/Docs/codeSnippets.ts
@@ -33,7 +33,7 @@ GET https://lanyard.org/api/v1/tree?root={root}
 
   // in general you can ignore the two following fields
   "leafTypeDescriptor": null, // or an array of solidity types
-  "packedEncoding": null // or a boolean value
+  "packedEncoding": true // a boolean value
 }
 `.trim()
 


### PR DESCRIPTION
null was removed as a value in #60, this updates docs
to reflect that