### PR TITLE
api: don't log errors for 404s

### DIFF
--- a/api/root.go
+++ b/api/root.go
@@ -54,7 +54,7 @@ func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
 		&rr.Root,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
-		s.sendJSONError(r, w, err, http.StatusNotFound, "root not found for proofs")
+		s.sendJSONError(r, w, nil, http.StatusNotFound, "root not found for proofs")
 		return
 	} else if err != nil {
 		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting root")

--- a/api/tree.go
+++ b/api/tree.go
@@ -189,7 +189,7 @@ func (s *Server) GetTree(w http.ResponseWriter, r *http.Request) {
 		&tr.Packed,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
-		s.sendJSONError(r, w, err, http.StatusNotFound, "tree not found for root")
+		s.sendJSONError(r, w, nil, http.StatusNotFound, "tree not found for root")
 		return
 	} else if err != nil {
 		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting tree")


### PR DESCRIPTION
seeing a lot of errors in our logs for 404s. these aren't errors
per se, for logging purposes let's not treat them like one