### PR TITLE
api: don't log requests to health endpoint

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -131,11 +131,13 @@ func tracingHandler(env, service, sha string, h http.Handler) http.Handler {
 		requestStart := time.Now()
 		h.ServeHTTP(sc, r.WithContext(ctx))
 
-		// log every request
-		log.Info().
-			Int("status", sc.status).
-			Dur("duration", time.Since(requestStart)).
-			Msg("")
+		if r.URL.Path != "/health" {
+			// log every request
+			log.Info().
+				Int("status", sc.status).
+				Dur("duration", time.Since(requestStart)).
+				Msg("")
+		}
 
 		span.SetTag(ext.HTTPCode, sc.status)
 	})


### PR DESCRIPTION
most of our request logs are health check requests, let's
omit health from our default request logging