### PR TITLE
pgx: set a minimum connection count

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -75,7 +75,8 @@ func main() {
 		dbc.ConnConfig.LogLevel = pgx.LogLevelTrace
 	}
 
-	dbc.MaxConns = 20
+	dbc.MinConns = 10
+	dbc.MaxConns = 30
 	db, err := pgxpool.ConnectConfig(ctx, dbc)
 	check(err)
 


### PR DESCRIPTION
we're seeing sporadic public read latency. this might be because
the server needs to open up new connections to the pool. let's
try to keep more connections open at a time