### PR TITLE
api: cache responses

### DIFF
--- a/api/proof.go
+++ b/api/proof.go
@@ -55,6 +55,7 @@ func (s *Server) GetProof(w http.ResponseWriter, r *http.Request) {
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		s.sendJSONError(r, w, nil, http.StatusNotFound, "tree not found")
+		w.Header().Set("Cache-Control", "public, max-age=60")
 		return
 	} else if err != nil {
 		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting proof")
@@ -62,8 +63,11 @@ func (s *Server) GetProof(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// cache for 1 year if we're returning an unhashed leaf proof
+	// or 60 seconds for an address proof
 	if leaf != "" {
 		w.Header().Set("Cache-Control", "public, max-age=31536000")
+	} else {
+		w.Header().Set("Cache-Control", "public, max-age=60")
 	}
 	s.sendJSON(r, w, resp)
 }

--- a/api/root.go
+++ b/api/root.go
@@ -55,6 +55,7 @@ func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		s.sendJSONError(r, w, nil, http.StatusNotFound, "root not found for proofs")
+		w.Header().Set("Cache-Control", "public, max-age=60")
 		return
 	} else if err != nil {
 		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting root")

--- a/api/root.go
+++ b/api/root.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/jackc/pgx/v4"
 )
 
 func proofURLToDBQuery(param string) string {
@@ -54,14 +53,12 @@ func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
 	roots := make([]hexutil.Bytes, 0)
 	rb := make(hexutil.Bytes, 0)
 
-
-
 	if err != nil {
 		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting root")
 		return
 	} else if len(roots) == 0 { // db.QueryFunc doesn't return pgx.ErrNoRows
-    w.Header().Set("Cache-Control", "public, max-age=60")
-	  s.sendJSONError(r, w, nil, http.StatusNotFound, "root not found for proofs")
+		w.Header().Set("Cache-Control", "public, max-age=60")
+		s.sendJSONError(r, w, nil, http.StatusNotFound, "root not found for proofs")
 		return
 	}
 

--- a/api/tree.go
+++ b/api/tree.go
@@ -190,6 +190,7 @@ func (s *Server) GetTree(w http.ResponseWriter, r *http.Request) {
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		s.sendJSONError(r, w, nil, http.StatusNotFound, "tree not found for root")
+		w.Header().Set("Cache-Control", "public, max-age=60")
 		return
 	} else if err != nil {
 		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting tree")


### PR DESCRIPTION
adds a 60 second cache to:
- 404s on get tree
- 404s on get root
- 404s on get proof
- address lookup on get proof