### PR TITLE
api: fix root query to be correctly specific

### DIFF
--- a/api/root.go
+++ b/api/root.go
@@ -61,11 +61,11 @@ func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
 		return nil
 	})
 
-	if len(rr.Root) == 0 {
-		s.sendJSONError(r, w, nil, http.StatusNotFound, "root not found for proofs")
-		return
-	} else if err != nil {
+	if err != nil {
 		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting root")
+		return
+	} else if len(rr.Root) == 0 {
+		s.sendJSONError(r, w, nil, http.StatusNotFound, "root not found for proofs")
 		return
 	}
 

--- a/api/root.go
+++ b/api/root.go
@@ -45,7 +45,7 @@ func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
 	const q = `
 		SELECT root
 		FROM trees
-		WHERE proofs_array(proofs) @> proofs_array($1)
+		WHERE proofs_array(proofs) <@ proofs_array($1)
 		LIMIT 1
 	`
 

--- a/api/root.go
+++ b/api/root.go
@@ -64,7 +64,7 @@ func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.sendJSONError(r, w, err, http.StatusInternalServerError, "selecting root")
 		return
-	} else if len(rr.Root) == 0 {
+	} else if len(rr.Root) == 0 { // db.QueryFunc doesn't return pgx.ErrNoRows
 		s.sendJSONError(r, w, nil, http.StatusNotFound, "root not found for proofs")
 		return
 	}

--- a/api/root.go
+++ b/api/root.go
@@ -61,7 +61,7 @@ func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
 		return nil
 	})
 
-	if errors.Is(err, pgx.ErrNoRows) || len(rr.Root) == 0 {
+	if len(rr.Root) == 0 {
 		s.sendJSONError(r, w, nil, http.StatusNotFound, "root not found for proofs")
 		return
 	} else if err != nil {


### PR DESCRIPTION
this updates the query operator from `@>` to `<@`

by consulting the [pg docs](https://www.postgresql.org/docs/14/functions-array.html), i now believe that this is the best option.

but would appreciate someone double checking my read. running the query, even with a limit 1, seems to a. produce the correct result and b. use the index.

sample query:

```sql
SELECT root                                                                                                                                                              FROM trees                                                                                                                                                                                                     WHERE proofs_array(proofs) <@ proofs_array('[{"proof": ["0xbf8309061f4b874aa1a5aca309e3374c3eef76cfea11233c3b14ec03f0af0405"]}]')
limit 1;
```