### PR TITLE
fix: simplify data model, proofs_hashes table

### DIFF
--- a/api/migrations/migrations.go
+++ b/api/migrations/migrations.go
@@ -120,9 +120,10 @@ var Migrations = []migrate.Migration{
 		Name: "2023-06-26.0.proofs_hashes.sql",
 		SQL: `
 		CREATE TABLE proofs_hashes (
-			hash bytea PRIMARY KEY,
+			hash bytea,
 			root bytea
 		);
+		CREATE INDEX proofs_hashes_hash_idx ON proofs_hashes(hash);
 		`,
 	},
 }

--- a/api/migrations/migrations.go
+++ b/api/migrations/migrations.go
@@ -119,11 +119,11 @@ var Migrations = []migrate.Migration{
 	{
 		Name: "2023-06-26.0.proofs_hashes.sql",
 		SQL: `
-		CREATE TABLE proofs_hashes (
+		CREATE TABLE IF NOT EXISTS proofs_hashes (
 			hash bytea,
 			root bytea
 		);
-		CREATE INDEX proofs_hashes_hash_idx ON proofs_hashes(hash);
+		CREATE INDEX IF NOT EXISTS proofs_hashes_hash_idx ON proofs_hashes (hash);
 		`,
 	},
 }

--- a/api/migrations/migrations.go
+++ b/api/migrations/migrations.go
@@ -116,4 +116,13 @@ var Migrations = []migrate.Migration{
 		CREATE INDEX proofs_arr_idx ON trees_proofs USING GIN ((proofs_array(proofs)));
 		`,
 	},
+	{
+		Name: "2023-06-26.0.proofs_hashes.sql",
+		SQL: `
+		CREATE TABLE proofs_hashes (
+			hash bytea PRIMARY KEY,
+			root bytea
+		);
+		`,
+	},
 }

--- a/api/migrations/scripts/000-rebuild-proofs-hashes/main.go
+++ b/api/migrations/scripts/000-rebuild-proofs-hashes/main.go
@@ -102,6 +102,11 @@ func main() {
 		check(err)
 	}
 
+	if len(trees) == 0 {
+		log.Println("no trees to process")
+		return
+	}
+
 	log.Printf("migrating %d trees", len(trees))
 
 	tx, err := db.Begin(ctx)

--- a/api/migrations/scripts/000-rebuild-proofs-hashes/main.go
+++ b/api/migrations/scripts/000-rebuild-proofs-hashes/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"runtime"
+	"runtime/debug"
+	"sync"
+
+	"github.com/contextwtf/lanyard/merkle"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"golang.org/x/sync/errgroup"
+)
+
+func check(err error) {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "processor error: %s", err)
+		debug.PrintStack()
+		os.Exit(1)
+	}
+}
+
+func hashProof(p [][]byte) []byte {
+	return crypto.Keccak256(p...)
+}
+
+func migrateTree(
+	ctx context.Context,
+	tx pgx.Tx,
+	leaves [][]byte,
+) error {
+	tree := merkle.New(leaves)
+
+	var (
+		proofHashes = [][]any{}
+		eg          errgroup.Group
+		pm          sync.Mutex
+	)
+	eg.SetLimit(runtime.NumCPU())
+
+	for _, l := range leaves {
+		l := l //avoid capture
+		eg.Go(func() error {
+			pf := tree.Proof(l)
+			if !merkle.Valid(tree.Root(), pf, l) {
+				return errors.New("invalid proof for tree")
+			}
+			proofHash := hashProof(pf)
+			pm.Lock()
+			proofHashes = append(proofHashes, []any{tree.Root(), proofHash})
+			pm.Unlock()
+			return nil
+		})
+	}
+	err := eg.Wait()
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.CopyFrom(ctx, pgx.Identifier{"proofs_hashes"},
+		[]string{"root", "hash"},
+		pgx.CopyFromRows(proofHashes),
+	)
+
+	return err
+}
+
+func main() {
+	ctx := context.Background()
+	const defaultPGURL = "postgres:///al"
+	dburl := os.Getenv("DATABASE_URL")
+	if dburl == "" {
+		dburl = defaultPGURL
+	}
+	dbc, err := pgxpool.ParseConfig(dburl)
+	check(err)
+
+	db, err := pgxpool.ConnectConfig(ctx, dbc)
+	check(err)
+
+	log.Println("fetching roots from db")
+	const q = `
+		SELECT unhashed_leaves
+		FROM trees
+		WHERE root not in (select root from proofs_hashes group by 1)
+	`
+	rows, err := db.Query(ctx, q)
+	check(err)
+	defer rows.Close()
+
+	trees := [][][]byte{}
+
+	for rows.Next() {
+		var t [][]byte
+		err := rows.Scan(&t)
+		trees = append(trees, t)
+		check(err)
+	}
+
+	log.Printf("migrating %d trees", len(trees))
+
+	tx, err := db.Begin(ctx)
+	check(err)
+	defer tx.Rollback(ctx)
+
+	var count int
+
+	for _, tree := range trees {
+		err = migrateTree(ctx, tx, tree)
+		check(err)
+		count++
+		if count%1000 == 0 {
+			log.Printf("migrated %d/%d trees", count, len(trees))
+		}
+	}
+
+	log.Printf("committing %d trees", len(trees))
+	err = tx.Commit(ctx)
+	check(err)
+	log.Printf("done")
+}

--- a/api/proof.go
+++ b/api/proof.go
@@ -27,7 +27,7 @@ func (s *Server) GetProof(w http.ResponseWriter, r *http.Request) {
 		s.sendJSONError(r, w, nil, http.StatusBadRequest, "missing root")
 		return
 	}
-	if r.URL.Query().Get("unhashedLeaf") == "" && r.URL.Query().Get("address") == "" {
+	if len(leaf) == 0 && addr == (common.Address{}) {
 		s.sendJSONError(r, w, nil, http.StatusBadRequest, "missing leaf")
 		return
 	}

--- a/api/root.go
+++ b/api/root.go
@@ -43,7 +43,8 @@ func (s *Server) GetRoot(w http.ResponseWriter, r *http.Request) {
 	const q = `
 		SELECT root
 		FROM proofs_hashes
-		WHERE hash = $1;
+		WHERE hash = $1
+		group by 1;
 	`
 	var (
 		roots []hexutil.Bytes


### PR DESCRIPTION
## motivation

historically, we've kept a column called `proofs` on the trees table. this is a jsonb column that contained all of the proofs for a tree.

at scale, this caused a couple of issues. the first thing that we saw is that it became too expensive to make a GIN index on proofs at the time of insert. so, we created the `trees_proofs` table which is a copy of the trees table, but replicated in the background with the index. this worked for a while. a couple of weeks ago, we noticed that the `trees` and `trees_proofs` table became out of date. the [background job](https://github.com/contextwtf/lanyard/blob/82f31584ac7f887057170b1b39315ef1380269be/cmd/api/main.go#L37-L54) to backfill the trees was just stalling & deadlocking. we tried a couple of fixes (#97 + #98), but neither worked. this had the effect of breaking the proofs -> roots endpoint for new trees.

simultaneously, we noticed that with larger trees of 200K+ addresses, the proofs column on `trees` was too large to even insert. the limit of a jsonb column is 255MB, which we were hitting.

## resolution

this pull request fixes these issues by creating a new table that we write to at time of tree creation in a tx, called `proofs_hashes`. this table is very simple: [root, keccak256(proofs)]. we can efficiently query this when we want to look up roots for a given tree.

to make this work, we also have to update the code to generate a proof for a given hash. instead of querying the proof from the DB, we have to fetch the whole tree and recalculate it. the interesting thing is, for very large trees in production, this already takes 500ms when fetching from the db. testing in local dev yields response times of 200ms. this isn't perfect given that production doesn't run the db on the same instance, but i think it's safe to say that calculating the tree is not the bottleneck. will monitor after this is merged. also writes seem to be faster, because we're sending less data over the wire to postgres [no more 500MB json blobs! even for a 200K item tree, it's closer to 10-20MB]

## todo

- [x] write migration script to backfill the `proofs_hashes` table
- after this is merged, a migration to delete the unneeded tables/data