### PR TITLE
cleanup: drop trees_proofs table + proofs columns

### DIFF
--- a/api/migrations/migrations.go
+++ b/api/migrations/migrations.go
@@ -126,4 +126,11 @@ var Migrations = []migrate.Migration{
 		CREATE INDEX IF NOT EXISTS proofs_hashes_hash_idx ON proofs_hashes (hash);
 		`,
 	},
+	{
+		Name: "2023-06-26.1.drop_data.sql",
+		SQL: `
+		ALTER TABLE "trees" DROP COLUMN "proofs";
+		DROP TABLE "trees_proofs";
+		`,
+	},
 }


### PR DESCRIPTION
we no longer write or read to `trees_proofs` nor the `proofs` column on trees as of #101. this pull request drops the column.