### PR TITLE
trees: lower cache control from one hour to 5 seconds

### DIFF
--- a/api/tree.go
+++ b/api/tree.go
@@ -267,6 +267,6 @@ func (s *Server) GetTree(w http.ResponseWriter, r *http.Request) {
 
 	tr.LeafCount = len(tr.UnhashedLeaves)
 
-	w.Header().Set("Cache-Control", "public, max-age=3600")
+	w.Header().Set("Cache-Control", "public, max-age=5")
 	s.sendJSON(r, w, tr)
 }


### PR DESCRIPTION
this information is critical, and after #101 it's very fast (<1ms) to query. let's bring caching in line with that